### PR TITLE
Pass full data to callback

### DIFF
--- a/contracts/proxy/src/state.rs
+++ b/contracts/proxy/src/state.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Addr, Binary};
+use cosmwasm_std::{Addr, SubMsgResponse};
 use cw_storage_plus::Item;
 
 /// Stores the instantiator of the contract.
@@ -6,4 +6,4 @@ pub const INSTANTIATOR: Item<Addr> = Item::new("owner");
 
 /// Stores a list of callback's currently being collected. Has no
 /// value if none are being collected.
-pub const COLLECTOR: Item<Vec<Option<Binary>>> = Item::new("callbacks");
+pub const COLLECTOR: Item<Vec<Option<SubMsgResponse>>> = Item::new("callbacks");

--- a/contracts/voice/src/ibc.rs
+++ b/contracts/voice/src/ibc.rs
@@ -97,11 +97,11 @@ pub fn reply(_deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, Contract
                 .add_attribute("ack_error", &e)
                 .set_data(ack_fail(e)),
             SubMsgResult::Ok(_) => {
-                let data = parse_reply_execute_data(msg)
+                let data = parse_reply_execute_data(msg.clone())
                     .expect("execution succeded")
                     .data
                     .expect("proxy should set data");
-                match from_binary::<Vec<Option<Binary>>>(&data) {
+                match from_binary::<Vec<Binary>>(&data) {
                     Ok(d) => Response::default().set_data(ack_success(d)),
                     Err(e) => Response::default()
                         .set_data(ack_fail(format!("unmarshaling callback data: ({e})"))),

--- a/packages/polytone/src/ack.rs
+++ b/packages/polytone/src/ack.rs
@@ -5,7 +5,7 @@ pub use crate::callback::Callback;
 pub type Ack = Callback;
 
 /// Serializes an ACK-SUCCESS containing the provided data.
-pub fn ack_success(c: Vec<Option<Binary>>) -> Binary {
+pub fn ack_success(c: Vec<Binary>) -> Binary {
     to_binary(&Callback::Success(c)).unwrap()
 }
 

--- a/packages/polytone/src/callback.rs
+++ b/packages/polytone/src/callback.rs
@@ -32,7 +32,7 @@ pub struct CallbackMessage {
 pub enum Callback {
     /// Data returned from the host chain. Index n corresponds to the
     /// result of executing the nth message/query.
-    Success(Vec<Option<Binary>>),
+    Success(Vec<Binary>),
     /// The first error that occured while executing the requested
     /// messages/queries.
     Error(String),

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -139,7 +139,7 @@ require (
 	golang.org/x/text v0.7.0 // indirect
 	google.golang.org/genproto v0.0.0-20230125152338-dcaf20b6aeaa // indirect
 	google.golang.org/grpc v1.53.0 // indirect
-	google.golang.org/protobuf v1.28.2-0.20220831092852-f930b1dc76e8 // indirect
+	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -1378,6 +1378,8 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.2-0.20220831092852-f930b1dc76e8 h1:KR8+MyP7/qOlV+8Af01LtjL04bu7on42eVsxT4EyBQk=
 google.golang.org/protobuf v1.28.2-0.20220831092852-f930b1dc76e8/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
+google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/tests/simtests/contract.go
+++ b/tests/simtests/contract.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/CosmWasm/wasmd/x/wasm/ibctesting"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	_ "github.com/cosmos/gogoproto/gogoproto"
 )
 
 type NoteInstantiate struct {
@@ -60,8 +61,30 @@ type CallbackMessage struct {
 }
 
 type Callback struct {
-	Success []string `json:"success,omitempty"`
+	Success [][]byte `json:"success,omitempty"`
 	Error   string   `json:"error,omitempty"`
+}
+
+type CallbackExecute struct {
+	Success []SubMsgResponse `json:"success,omitempty"`
+	Error   string           `json:"error,omitempty"`
+}
+
+type SubMsgResponse struct {
+	Events []Event `json:"events"`
+	Data   []byte  `json:"data,omitempty"`
+}
+
+type Events []Event
+type Event struct {
+	Type       string          `json:"type"`
+	Attributes EventAttributes `json:"attributes"`
+}
+
+type EventAttributes []EventAttribute
+type EventAttribute struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }
 
 type Empty struct{}

--- a/tests/simtests/functionality_suite.go
+++ b/tests/simtests/functionality_suite.go
@@ -1,6 +1,7 @@
 package simtests
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/CosmWasm/wasmd/x/wasm/ibctesting"
@@ -132,5 +133,30 @@ func (s *Suite) RoundtripMessage(t *testing.T, path *ibctesting.Path, account *A
 	callback := callbacks[len(callbacks)-1]
 	require.Equal(t, account.Address.String(), callback.Initiator)
 	require.Equal(t, "aGVsbG8K", callback.InitiatorMsg)
+
 	return callback.Result, nil
+}
+
+func (s *Suite) parseCallbackExecute(t *testing.T, data Callback) CallbackExecute {
+	if len(data.Success) > 0 {
+		var subMsgs []SubMsgResponse
+
+		for _, s := range data.Success {
+			var subMsg SubMsgResponse
+			err := json.Unmarshal(s, &subMsg)
+			require.NoError(t, err)
+
+			subMsgs = append(subMsgs, subMsg)
+		}
+
+		return CallbackExecute{
+			Success: subMsgs,
+			Error:   "",
+		}
+	}
+
+	return CallbackExecute{
+		Success: []SubMsgResponse{},
+		Error:   data.Error,
+	}
 }

--- a/tests/simtests/unmarshal.go
+++ b/tests/simtests/unmarshal.go
@@ -1,0 +1,25 @@
+package simtests
+
+import (
+	"testing"
+
+	"github.com/CosmWasm/wasmd/x/wasm/types"
+)
+
+func unmarshalExecute(t *testing.T, data []byte) types.MsgExecuteContractResponse {
+	var w types.MsgExecuteContractResponse
+	w.Unmarshal(data)
+	return w
+}
+
+func unmarshalInstantiate(t *testing.T, data []byte) types.MsgInstantiateContractResponse {
+	var w types.MsgInstantiateContractResponse
+	w.Unmarshal(data)
+	return w
+}
+
+func unmarshalInstantiate2(t *testing.T, data []byte) types.MsgInstantiateContract2Response {
+	var w types.MsgInstantiateContract2Response
+	w.Unmarshal(data)
+	return w
+}


### PR DESCRIPTION
Should close/fix #3.

Still a draft because we still have 1 question to answer regarding this (related to [this](https://github.com/DA0-DA0/polytone/issues/3#issuecomment-1490953428)) :
How do we pass data to callback? 

We basically have 2 callback types, execute type and query type, in this PR I handle both of those in a single callback type, but this creates an issue where you need to parse the returned data based on what you expect (either a query or an execution) or you need to match based on the parsing result rather then on a type

The PR works, but it feels almost unnatural:

Because the query msg return vector of binary, we also need to turn SubMsgResponse into a binary (to fulfil the callback single type), and then we need to do several parsing steps to get our actual data.

I suggest we move into 2 callback types corresponding to the Rx 2 msg types (query and execute), that way we can remove the need to encode SubMsgResponse into binary, and it will be much easier to parse the needed data, and will make the callback handler much easier to write/read.

We should also extend tester contract to include some callback handler logic, where you do X when you get a query, and do Y when you get an execute callback.

Hope it makes sense.