### PR TITLE
added controller logic

### DIFF
--- a/contracts/note/src/contract.rs
+++ b/contracts/note/src/contract.rs
@@ -9,7 +9,7 @@ use polytone::{callback, ibc};
 
 use crate::error::ContractError;
 use crate::msg::{ExecuteMsg, InstantiateMsg, Pair, QueryMsg};
-use crate::state::{CHANNEL, CONNECTION_REMOTE_PORT};
+use crate::state::{CHANNEL, CONNECTION_REMOTE_PORT, CONTROLLER};
 
 const CONTRACT_NAME: &str = "crates.io:polytone-note";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -23,6 +23,7 @@ pub fn instantiate(
 ) -> Result<Response, ContractError> {
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     let mut response = Response::default().add_attribute("method", "instantiate");
+
     if let Some(Pair {
         connection_id,
         remote_port,
@@ -33,6 +34,11 @@ pub fn instantiate(
             .add_attribute("pair_port", remote_port.to_string());
         CONNECTION_REMOTE_PORT.save(deps.storage, &(connection_id, remote_port))?;
     };
+
+    if let Some(controller) = msg.controller {
+        response = response.add_attribute("controller", controller.to_string());
+        CONTROLLER.save(deps.storage, &deps.api.addr_validate(&controller)?)?;
+    }
     Ok(response)
 }
 
@@ -43,33 +49,64 @@ pub fn execute(
     info: MessageInfo,
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
-    let (msg, callback, timeout_seconds, request_type) = match msg {
+    let (msg, callback, timeout_seconds, request_type, on_behalf_of) = match msg {
         ExecuteMsg::Execute {
             msgs,
             callback,
             timeout_seconds,
+            on_behalf_of,
         } => (
             ibc::Msg::Execute { msgs },
             callback,
             timeout_seconds,
             CallbackRequestType::Execute,
+            on_behalf_of,
         ),
         ExecuteMsg::Query {
             msgs,
             callback,
             timeout_seconds,
+            on_behalf_of,
         } => (
             ibc::Msg::Query { msgs },
             Some(callback),
             timeout_seconds,
             CallbackRequestType::Query,
+            on_behalf_of,
         ),
     };
+
+    // Check if the note is controlled
+    let sender = match CONTROLLER.load(deps.storage) {
+        Ok(controller) => {
+            if controller != info.sender {
+                return Err(ContractError::NotController);
+            }
+
+            // Note is controlled and controller is the sender
+            // now verify we have on_behalf_of set to know who
+            // the real sender is
+            if let Some(sender) = on_behalf_of {
+                deps.api.addr_validate(&sender)
+            } else {
+                // Note is controlled, but on_behalf_of is not set
+                return Err(ContractError::OnBehalfOfNotSet);
+            }
+        }
+        // Note is not controlled, but on_behalf_of is set
+        // probably something was misconfigured
+        Err(_) => {
+            if on_behalf_of.is_some() {
+                return Err(ContractError::NotControlledButOnBehalfIsSet);
+            }
+            Ok(info.sender)
+        }
+    }?;
 
     callback::request_callback(
         deps.storage,
         deps.api,
-        info.sender.clone(),
+        sender.clone(),
         callback,
         request_type,
     )?;
@@ -82,7 +119,7 @@ pub fn execute(
         .add_message(IbcMsg::SendPacket {
             channel_id,
             data: to_binary(&ibc::Packet {
-                sender: info.sender.into_string(),
+                sender: sender.into_string(),
                 msg,
             })
             .expect("msgs are known to be serializable"),

--- a/contracts/note/src/error.rs
+++ b/contracts/note/src/error.rs
@@ -1,7 +1,7 @@
 use cosmwasm_std::StdError;
 use thiserror::Error;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq)]
 pub enum ContractError {
     #[error(transparent)]
     Std(#[from] StdError),
@@ -19,4 +19,11 @@ pub enum ContractError {
 
     #[error("contract has no pair, establish a channel with a voice module to create one")]
     NoPair,
+
+    #[error("Note is not controlled, but 'on_behalf_of' is set")]
+    NotControlledButOnBehalfIsSet,
+    #[error("Note is controlled, but this address is not the controller")]
+    NotController,
+    #[error("Note is controlled, but 'on_behalf_of' is not set")]
+    OnBehalfOfNotSet,
 }

--- a/contracts/note/src/msg.rs
+++ b/contracts/note/src/msg.rs
@@ -10,6 +10,9 @@ pub struct InstantiateMsg {
     /// pair, it will never handshake with a different voice module,
     /// even after channel closure.
     pub pair: Option<Pair>,
+    /// This is the controller of the note. if controller is set
+    /// only that address can execute msgs on this note.
+    pub controller: Option<String>,
 }
 
 #[cw_serde]
@@ -18,6 +21,7 @@ pub enum ExecuteMsg {
     /// a callback of Vec<QuerierResult>, or ACK-FAIL if unmarshalling
     /// any of the query requests fails.
     Query {
+        on_behalf_of: Option<String>,
         msgs: Vec<QueryRequest<Empty>>,
         callback: CallbackRequest,
         timeout_seconds: Uint64,
@@ -28,6 +32,7 @@ pub enum ExecuteMsg {
     /// object. Optionaly, returns a callback of `Vec<Callback>` where
     /// index `i` corresponds to the callback for `msgs[i]`.
     Execute {
+        on_behalf_of: Option<String>,
         msgs: Vec<CosmosMsg<Empty>>,
         callback: Option<CallbackRequest>,
         timeout_seconds: Uint64,

--- a/contracts/note/src/state.rs
+++ b/contracts/note/src/state.rs
@@ -8,4 +8,4 @@ pub const CONNECTION_REMOTE_PORT: Item<(String, String)> = Item::new("a");
 /// no channel is active.
 pub const CHANNEL: Item<String> = Item::new("b");
 
-pub const CONTROLLER : Item<Addr> = Item::new("c");
+pub const CONTROLLER: Item<Addr> = Item::new("c");

--- a/contracts/note/src/state.rs
+++ b/contracts/note/src/state.rs
@@ -1,3 +1,4 @@
+use cosmwasm_std::Addr;
 use cw_storage_plus::Item;
 
 /// (Connection-ID, Remote port) of this contract's pair.
@@ -6,3 +7,5 @@ pub const CONNECTION_REMOTE_PORT: Item<(String, String)> = Item::new("a");
 /// Channel-ID of the channel currently connected. Holds no value when
 /// no channel is active.
 pub const CHANNEL: Item<String> = Item::new("b");
+
+pub const CONTROLLER : Item<Addr> = Item::new("c");

--- a/contracts/note/src/tests.rs
+++ b/contracts/note/src/tests.rs
@@ -1,156 +1,154 @@
-#[cfg(test)]
-mod tests {
-    use cosmwasm_std::{
-        testing::{mock_dependencies, mock_env, mock_info},
-        to_binary, Uint64, WasmMsg,
-    };
 
-    use crate::{
-        contract::{execute, instantiate},
-        error::ContractError,
-        msg::InstantiateMsg,
-        state::CHANNEL,
-    };
+use cosmwasm_std::{
+    testing::{mock_dependencies, mock_env, mock_info},
+    to_binary, Uint64, WasmMsg,
+};
 
-    #[test]
-    fn simple_note() {
-        let mut deps = mock_dependencies();
-        let env = mock_env();
-        let info = mock_info("sender", &[]);
+use crate::{
+    contract::{execute, instantiate},
+    error::ContractError,
+    msg::InstantiateMsg,
+    state::CHANNEL,
+};
 
-        instantiate(
-            deps.as_mut(),
-            env.clone(),
-            info.clone(),
-            InstantiateMsg {
-                pair: None,
-                controller: None,
-            },
-        )
-        .unwrap();
-        CHANNEL
-            .save(deps.as_mut().storage, &"some_channel".to_string())
-            .unwrap();
+#[test]
+fn simple_note() {
+    let mut deps = mock_dependencies();
+    let env = mock_env();
+    let info = mock_info("sender", &[]);
 
-        execute(
-            deps.as_mut(),
-            env.clone(),
-            info.clone(),
-            crate::msg::ExecuteMsg::Execute {
-                on_behalf_of: None,
-                msgs: vec![WasmMsg::Execute {
-                    contract_addr: "some_addr".to_string(),
-                    msg: to_binary("some_msg").unwrap(),
-                    funds: vec![],
-                }
-                .into()],
-                callback: None,
-                timeout_seconds: Uint64::new(10000),
-            },
-        )
+    instantiate(
+        deps.as_mut(),
+        env.clone(),
+        info.clone(),
+        InstantiateMsg {
+            pair: None,
+            controller: None,
+        },
+    )
+    .unwrap();
+    CHANNEL
+        .save(deps.as_mut().storage, &"some_channel".to_string())
         .unwrap();
 
-        // note is controlled, but `on_behalf_of` is set should error
-        let err = execute(
-            deps.as_mut(),
-            env,
-            info,
-            crate::msg::ExecuteMsg::Execute {
-                on_behalf_of: Some("some_addr".to_string()),
-                msgs: vec![WasmMsg::Execute {
-                    contract_addr: "some_addr".to_string(),
-                    msg: to_binary("some_msg").unwrap(),
-                    funds: vec![],
-                }
-                .into()],
-                callback: None,
-                timeout_seconds: Uint64::new(10000),
-            },
-        )
-        .unwrap_err();
+    execute(
+        deps.as_mut(),
+        env.clone(),
+        info.clone(),
+        crate::msg::ExecuteMsg::Execute {
+            on_behalf_of: None,
+            msgs: vec![WasmMsg::Execute {
+                contract_addr: "some_addr".to_string(),
+                msg: to_binary("some_msg").unwrap(),
+                funds: vec![],
+            }
+            .into()],
+            callback: None,
+            timeout_seconds: Uint64::new(10000),
+        },
+    )
+    .unwrap();
 
-        assert_eq!(err, ContractError::NotControlledButOnBehalfIsSet)
-    }
+    // note is controlled, but `on_behalf_of` is set should error
+    let err = execute(
+        deps.as_mut(),
+        env,
+        info,
+        crate::msg::ExecuteMsg::Execute {
+            on_behalf_of: Some("some_addr".to_string()),
+            msgs: vec![WasmMsg::Execute {
+                contract_addr: "some_addr".to_string(),
+                msg: to_binary("some_msg").unwrap(),
+                funds: vec![],
+            }
+            .into()],
+            callback: None,
+            timeout_seconds: Uint64::new(10000),
+        },
+    )
+    .unwrap_err();
 
-    #[test]
-    fn controlled_note() {
-        let mut deps = mock_dependencies();
-        let env = mock_env();
-        let info = mock_info("sender", &[]);
-        let controller_info = mock_info("controller", &[]);
+    assert_eq!(err, ContractError::NotControlledButOnBehalfIsSet)
+}
 
-        instantiate(
-            deps.as_mut(),
-            env.clone(),
-            info.clone(),
-            InstantiateMsg {
-                pair: None,
-                controller: Some("controller".to_string()),
-            },
-        )
+#[test]
+fn controlled_note() {
+    let mut deps = mock_dependencies();
+    let env = mock_env();
+    let info = mock_info("sender", &[]);
+    let controller_info = mock_info("controller", &[]);
+
+    instantiate(
+        deps.as_mut(),
+        env.clone(),
+        info.clone(),
+        InstantiateMsg {
+            pair: None,
+            controller: Some("controller".to_string()),
+        },
+    )
+    .unwrap();
+    CHANNEL
+        .save(deps.as_mut().storage, &"some_channel".to_string())
         .unwrap();
-        CHANNEL
-            .save(deps.as_mut().storage, &"some_channel".to_string())
-            .unwrap();
 
-        execute(
-            deps.as_mut(),
-            env.clone(),
-            controller_info.clone(),
-            crate::msg::ExecuteMsg::Execute {
-                on_behalf_of: Some("some_addr".to_string()),
-                msgs: vec![WasmMsg::Execute {
-                    contract_addr: "some_addr".to_string(),
-                    msg: to_binary("some_msg").unwrap(),
-                    funds: vec![],
-                }
-                .into()],
-                callback: None,
-                timeout_seconds: Uint64::new(10000),
-            },
-        )
-        .unwrap();
+    execute(
+        deps.as_mut(),
+        env.clone(),
+        controller_info.clone(),
+        crate::msg::ExecuteMsg::Execute {
+            on_behalf_of: Some("some_addr".to_string()),
+            msgs: vec![WasmMsg::Execute {
+                contract_addr: "some_addr".to_string(),
+                msg: to_binary("some_msg").unwrap(),
+                funds: vec![],
+            }
+            .into()],
+            callback: None,
+            timeout_seconds: Uint64::new(10000),
+        },
+    )
+    .unwrap();
 
-        // note is controlled but `on_behalf_of` is not set, should error
-        let err = execute(
-            deps.as_mut(),
-            env.clone(),
-            controller_info,
-            crate::msg::ExecuteMsg::Execute {
-                on_behalf_of: None,
-                msgs: vec![WasmMsg::Execute {
-                    contract_addr: "some_addr".to_string(),
-                    msg: to_binary("some_msg").unwrap(),
-                    funds: vec![],
-                }
-                .into()],
-                callback: None,
-                timeout_seconds: Uint64::new(10000),
-            },
-        )
-        .unwrap_err();
+    // note is controlled but `on_behalf_of` is not set, should error
+    let err = execute(
+        deps.as_mut(),
+        env.clone(),
+        controller_info,
+        crate::msg::ExecuteMsg::Execute {
+            on_behalf_of: None,
+            msgs: vec![WasmMsg::Execute {
+                contract_addr: "some_addr".to_string(),
+                msg: to_binary("some_msg").unwrap(),
+                funds: vec![],
+            }
+            .into()],
+            callback: None,
+            timeout_seconds: Uint64::new(10000),
+        },
+    )
+    .unwrap_err();
 
-        assert_eq!(err, ContractError::OnBehalfOfNotSet);
+    assert_eq!(err, ContractError::OnBehalfOfNotSet);
 
-        // note is controlled but not controller called execute, should error
-        let err = execute(
-            deps.as_mut(),
-            env,
-            info,
-            crate::msg::ExecuteMsg::Execute {
-                on_behalf_of: Some("some_addr".to_string()),
-                msgs: vec![WasmMsg::Execute {
-                    contract_addr: "some_addr".to_string(),
-                    msg: to_binary("some_msg").unwrap(),
-                    funds: vec![],
-                }
-                .into()],
-                callback: None,
-                timeout_seconds: Uint64::new(10000),
-            },
-        )
-        .unwrap_err();
+    // note is controlled but not controller called execute, should error
+    let err = execute(
+        deps.as_mut(),
+        env,
+        info,
+        crate::msg::ExecuteMsg::Execute {
+            on_behalf_of: Some("some_addr".to_string()),
+            msgs: vec![WasmMsg::Execute {
+                contract_addr: "some_addr".to_string(),
+                msg: to_binary("some_msg").unwrap(),
+                funds: vec![],
+            }
+            .into()],
+            callback: None,
+            timeout_seconds: Uint64::new(10000),
+        },
+    )
+    .unwrap_err();
 
-        assert_eq!(err, ContractError::NotController)
-    }
+    assert_eq!(err, ContractError::NotController)
 }

--- a/contracts/note/src/tests.rs
+++ b/contracts/note/src/tests.rs
@@ -1,1 +1,156 @@
+#[cfg(test)]
+mod tests {
+    use cosmwasm_std::{
+        testing::{mock_dependencies, mock_env, mock_info},
+        to_binary, Uint64, WasmMsg,
+    };
 
+    use crate::{
+        contract::{execute, instantiate},
+        error::ContractError,
+        msg::InstantiateMsg,
+        state::CHANNEL,
+    };
+
+    #[test]
+    fn simple_note() {
+        let mut deps = mock_dependencies();
+        let env = mock_env();
+        let info = mock_info("sender", &[]);
+
+        instantiate(
+            deps.as_mut(),
+            env.clone(),
+            info.clone(),
+            InstantiateMsg {
+                pair: None,
+                controller: None,
+            },
+        )
+        .unwrap();
+        CHANNEL
+            .save(deps.as_mut().storage, &"some_channel".to_string())
+            .unwrap();
+
+        execute(
+            deps.as_mut(),
+            env.clone(),
+            info.clone(),
+            crate::msg::ExecuteMsg::Execute {
+                on_behalf_of: None,
+                msgs: vec![WasmMsg::Execute {
+                    contract_addr: "some_addr".to_string(),
+                    msg: to_binary("some_msg").unwrap(),
+                    funds: vec![],
+                }
+                .into()],
+                callback: None,
+                timeout_seconds: Uint64::new(10000),
+            },
+        )
+        .unwrap();
+
+        // note is controlled, but `on_behalf_of` is set should error
+        let err = execute(
+            deps.as_mut(),
+            env,
+            info,
+            crate::msg::ExecuteMsg::Execute {
+                on_behalf_of: Some("some_addr".to_string()),
+                msgs: vec![WasmMsg::Execute {
+                    contract_addr: "some_addr".to_string(),
+                    msg: to_binary("some_msg").unwrap(),
+                    funds: vec![],
+                }
+                .into()],
+                callback: None,
+                timeout_seconds: Uint64::new(10000),
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(err, ContractError::NotControlledButOnBehalfIsSet)
+    }
+
+    #[test]
+    fn controlled_note() {
+        let mut deps = mock_dependencies();
+        let env = mock_env();
+        let info = mock_info("sender", &[]);
+        let controller_info = mock_info("controller", &[]);
+
+        instantiate(
+            deps.as_mut(),
+            env.clone(),
+            info.clone(),
+            InstantiateMsg {
+                pair: None,
+                controller: Some("controller".to_string()),
+            },
+        )
+        .unwrap();
+        CHANNEL
+            .save(deps.as_mut().storage, &"some_channel".to_string())
+            .unwrap();
+
+        execute(
+            deps.as_mut(),
+            env.clone(),
+            controller_info.clone(),
+            crate::msg::ExecuteMsg::Execute {
+                on_behalf_of: Some("some_addr".to_string()),
+                msgs: vec![WasmMsg::Execute {
+                    contract_addr: "some_addr".to_string(),
+                    msg: to_binary("some_msg").unwrap(),
+                    funds: vec![],
+                }
+                .into()],
+                callback: None,
+                timeout_seconds: Uint64::new(10000),
+            },
+        )
+        .unwrap();
+
+        // note is controlled but `on_behalf_of` is not set, should error
+        let err = execute(
+            deps.as_mut(),
+            env.clone(),
+            controller_info,
+            crate::msg::ExecuteMsg::Execute {
+                on_behalf_of: None,
+                msgs: vec![WasmMsg::Execute {
+                    contract_addr: "some_addr".to_string(),
+                    msg: to_binary("some_msg").unwrap(),
+                    funds: vec![],
+                }
+                .into()],
+                callback: None,
+                timeout_seconds: Uint64::new(10000),
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(err, ContractError::OnBehalfOfNotSet);
+
+        // note is controlled but not controller called execute, should error
+        let err = execute(
+            deps.as_mut(),
+            env,
+            info,
+            crate::msg::ExecuteMsg::Execute {
+                on_behalf_of: Some("some_addr".to_string()),
+                msgs: vec![WasmMsg::Execute {
+                    contract_addr: "some_addr".to_string(),
+                    msg: to_binary("some_msg").unwrap(),
+                    funds: vec![],
+                }
+                .into()],
+                callback: None,
+                timeout_seconds: Uint64::new(10000),
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(err, ContractError::NotController)
+    }
+}


### PR DESCRIPTION
@0xekez I really like how simple and straight forward that implementation is. 
I added some unit tests to confirm all checks we do in contract are working correctly.

I think we are missing 2 things:
1. go tests to confirm this is working (don't see a reason why it won't)
2. `getController` query that returns `Option<String>`, if note is controlled, return the controller, if not, return None

PR is not to main so we can focus only on the controller changes