### PR TITLE
Improve errors, comments, and response attributes

### DIFF
--- a/contracts/proxy/src/contract.rs
+++ b/contracts/proxy/src/contract.rs
@@ -75,7 +75,7 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractEr
 
     match msg.result {
         SubMsgResult::Err(error) => Err(ContractError::MsgError {
-            index: collector.len() as u64,
+            index: msg.id,
             error,
         }),
         SubMsgResult::Ok(res) => {

--- a/contracts/voice/src/msg.rs
+++ b/contracts/voice/src/msg.rs
@@ -3,15 +3,21 @@ use cosmwasm_std::{Binary, Uint64};
 
 #[cw_serde]
 pub struct InstantiateMsg {
+    /// Code ID to use for instantiating proxy contracts.
     pub proxy_code_id: Uint64,
+    /// The max gas allowed in a single block.
     pub block_max_gas: Uint64,
 }
 
 #[cw_serde]
 pub enum ExecuteMsg {
+    /// Receives and handles an incoming packet.
     Rx {
+        /// The local connection id the packet arrived on.
         connection_id: String,
+        /// The port of the counterparty module.
         counterparty_port: String,
+        /// The packet data.
         data: Binary,
     },
 }
@@ -19,17 +25,23 @@ pub enum ExecuteMsg {
 #[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {
+    /// Queries the configured block max gas. Serialized as
+    /// `"block_max_gas"`.
     #[returns(Uint64)]
     BlockMaxGas,
-
+    /// Queries the configured proxy code ID. Serialized as
+    /// `"proxy_code_id"`.
     #[returns(Uint64)]
     ProxyCodeId,
 }
 
 #[cw_serde]
 pub enum MigrateMsg {
+    /// Updates the module's configuration.
     WithUpdate {
+        /// Code ID to use for instantiating proxy contracts.
         proxy_code_id: Uint64,
+        /// The max gas allowed in a single block.
         block_max_gas: Uint64,
-    }
+    },
 }


### PR DESCRIPTION
This fixes a small bug in the proxy contract that was returning the total number of messages and not the message that failed in an error message, adds some more documentation comments, and improves the verbosity of our response attributes.