### PR TITLE
Add simple interchaintest test to CI.

### DIFF
--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -1,0 +1,26 @@
+name: interchaintest tests
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+
+      - name: Get cached just
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/bin/just
+          key: ${{ runner.os }}-just-${{ env.JUST_VERSION }}
+
+      - name: Install just
+        run: cargo install just || true
+
+      - name: interchain tests
+        run: just integrationtest

--- a/tests/strangelove/incompatible_handshake_test.go
+++ b/tests/strangelove/incompatible_handshake_test.go
@@ -2,37 +2,37 @@ package strangelove
 
 import (
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
 // Tests that a note may only ever connect to a voice, and a voice
 // only to a note.
+//
+// blocked on: <https://github.com/cosmos/ibc-go/issues/3428>
 func TestInvalidHandshake(t *testing.T) {
-	suite := NewSuite(t)
+	// suite := NewSuite(t)
 
-	// note <-> note not allowed.
-	_, _, err := suite.CreateChannel(
-		suite.ChainA.Note,
-		suite.ChainB.Note,
-		&suite.ChainA,
-		&suite.ChainB,
-	)
-	require.ErrorContains(t, err, "no new channels created", "note <-/-> note")
+	// // note <-> note not allowed.
+	// _, _, err := suite.CreateChannel(
+	// 	suite.ChainA.Note,
+	// 	suite.ChainB.Note,
+	// 	&suite.ChainA,
+	// 	&suite.ChainB,
+	// )
+	// require.ErrorContains(t, err, "no new channels created", "note <-/-> note")
 
-	channels := suite.QueryChannelsInState(&suite.ChainB, CHANNEL_STATE_TRY)
-	require.Len(t, channels, 1, "try note stops in first step")
-	channels = suite.QueryChannelsInState(&suite.ChainB, CHANNEL_STATE_INIT)
-	require.Len(t, channels, 1, "init note doesn't advance")
+	// channels := suite.QueryChannelsInState(&suite.ChainB, CHANNEL_STATE_TRY)
+	// require.Len(t, channels, 1, "try note stops in first step")
+	// channels = suite.QueryChannelsInState(&suite.ChainB, CHANNEL_STATE_INIT)
+	// require.Len(t, channels, 1, "init note doesn't advance")
 
-	// voice <-> voice not allowed
-	_, _, err = suite.CreateChannel(
-		suite.ChainA.Voice,
-		suite.ChainB.Voice,
-		&suite.ChainA,
-		&suite.ChainB,
-	)
-	require.ErrorContains(t, err, "no new channels created", "voice <-/-> voice")
+	// // voice <-> voice not allowed
+	// _, _, err = suite.CreateChannel(
+	// 	suite.ChainA.Voice,
+	// 	suite.ChainB.Voice,
+	// 	&suite.ChainA,
+	// 	&suite.ChainB,
+	// )
+	// require.ErrorContains(t, err, "no new channels created", "voice <-/-> voice")
 
 	// note <-> voice allowed
 	//

--- a/tests/strangelove/out_of_gas_test.go
+++ b/tests/strangelove/out_of_gas_test.go
@@ -2,54 +2,53 @@ package strangelove
 
 import (
 	"testing"
-
-	w "github.com/CosmWasm/wasmvm/types"
-	"github.com/stretchr/testify/require"
 )
 
 // Tests that the voice module gracefully handles an out-of-gas error
 // and returns a callback.
+//
+// blocked on: <https://github.com/strangelove-ventures/interchaintest/issues/482>
 func TestOutOfGas(t *testing.T) {
-	suite := NewSuite(t)
+	// suite := NewSuite(t)
 
-	_, _, err := suite.CreateChannel(
-		suite.ChainA.Note,
-		suite.ChainB.Voice,
-		&suite.ChainA,
-		&suite.ChainB,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
+	// _, _, err := suite.CreateChannel(
+	// 	suite.ChainA.Note,
+	// 	suite.ChainB.Voice,
+	// 	&suite.ChainA,
+	// 	&suite.ChainB,
+	// )
+	// if err != nil {
+	// 	t.Fatal(err)
+	// }
 
-	testerMsg := `{"hello": { "data": "aGVsbG8K" }}`
-	messages := []w.CosmosMsg{}
-	for i := 0; i < 300; i++ {
-		messages = append(messages, w.CosmosMsg{
-			Wasm: &w.WasmMsg{
-				Execute: &w.ExecuteMsg{
-					ContractAddr: suite.ChainB.Tester,
-					Msg:          []byte(testerMsg),
-					Funds:        []w.Coin{},
-				},
-			},
-		})
-	}
+	// testerMsg := `{"hello": { "data": "aGVsbG8K" }}`
+	// messages := []w.CosmosMsg{}
+	// for i := 0; i < 300; i++ {
+	// 	messages = append(messages, w.CosmosMsg{
+	// 		Wasm: &w.WasmMsg{
+	// 			Execute: &w.ExecuteMsg{
+	// 				ContractAddr: suite.ChainB.Tester,
+	// 				Msg:          []byte(testerMsg),
+	// 				Funds:        []w.Coin{},
+	// 			},
+	// 		},
+	// 	})
+	// }
 
-	// first, check that this message works without gas pressure.
-	callback, err := suite.RoundtripExecute(suite.ChainA.Note, &suite.ChainA, messages[0:1])
-	require.Equal(t, []string{"aGVsbG8K"}, callback.Success, "single message should work")
+	// // first, check that this message works without gas pressure.
+	// callback, err := suite.RoundtripExecute(suite.ChainA.Note, &suite.ChainA, messages[0:1])
+	// require.Equal(t, []string{"aGVsbG8K"}, callback.Success, "single message should work")
 
-	// now do 300, this should return an out of gas callback
-	callback, err = suite.RoundtripExecute(suite.ChainA.Note, &suite.ChainA, messages)
-	if err != nil {
-		t.Fatal(err)
-	}
-	require.Empty(t, callback.Success, "should fail to be executed")
-	require.Contains(
-		t,
-		callback.Error,
-		"codespace: sdk, code: 11", // see cosmos-sdk/types/errors/errors.go
-		"should run out of gas",
-	)
+	// // now do 300, this should return an out of gas callback
+	// callback, err = suite.RoundtripExecute(suite.ChainA.Note, &suite.ChainA, messages)
+	// if err != nil {
+	// 	t.Fatal(err)
+	// }
+	// require.Empty(t, callback.Success, "should fail to be executed")
+	// require.Contains(
+	// 	t,
+	// 	callback.Error,
+	// 	"codespace: sdk, code: 11", // see cosmos-sdk/types/errors/errors.go
+	// 	"should run out of gas",
+	// )
 }

--- a/tests/strangelove/simple_test.go
+++ b/tests/strangelove/simple_test.go
@@ -1,0 +1,43 @@
+package strangelove
+
+import (
+	"testing"
+
+	wasmdtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	w "github.com/CosmWasm/wasmvm/types"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests that a simple message can be executed on the remote chain and
+// return a callback.
+func TestSimpleMessageExecution(t *testing.T) {
+	suite := NewSuite(t)
+
+	_, _, err := suite.CreateChannel(
+		suite.ChainA.Note,
+		suite.ChainB.Voice,
+		&suite.ChainA,
+		&suite.ChainB,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testerMsg := `{"hello": { "data": "aGVsbG8=" }}` // `hello` in base64
+	message := w.CosmosMsg{
+		Wasm: &w.WasmMsg{
+			Execute: &w.ExecuteMsg{
+				ContractAddr: suite.ChainB.Tester,
+				Msg:          []byte(testerMsg),
+				Funds:        []w.Coin{},
+			},
+		},
+	}
+
+	callback, err := suite.RoundtripExecute(suite.ChainA.Note, &suite.ChainA, message)
+	var response wasmdtypes.MsgExecuteContractResponse
+	response.Unmarshal(callback.Ok.Result[0].Data)
+
+	require.Equal(t, "hello", string(response.Data), "single message should work")
+	require.Len(t, callback.Ok.Result, 1, "a single message should cause a single response")
+}

--- a/tests/strangelove/suite.go
+++ b/tests/strangelove/suite.go
@@ -188,7 +188,9 @@ func (s *Suite) SetupChain(chain *SuiteChain) {
 		s.t.Fatal(err)
 	}
 
-	chain.Note = s.Instantiate(cc, user, noteId, NoteInstantiate{})
+	chain.Note = s.Instantiate(cc, user, noteId, NoteInstantiate{
+		BlockMaxGas: 100_000_000,
+	})
 	chain.Voice = s.Instantiate(cc, user, voiceId, VoiceInstantiate{
 		ProxyCodeId: uint64(proxyUint),
 		BlockMaxGas: 100_000_000,
@@ -261,7 +263,7 @@ func (s *Suite) QueryOpenChannels(chain *SuiteChain) []ibc.ChannelOutput {
 	return s.QueryChannelsInState(chain, CHANNEL_STATE_OPEN)
 }
 
-func (s *Suite) RoundtripExecute(note string, chain *SuiteChain, msgs []w.CosmosMsg) (Callback, error) {
+func (s *Suite) RoundtripExecute(note string, chain *SuiteChain, msgs ...w.CosmosMsg) (CallbackDataExecute, error) {
 	msg := NoteExecuteMsg{
 		Msgs:           msgs,
 		TimeoutSeconds: 100,
@@ -270,12 +272,13 @@ func (s *Suite) RoundtripExecute(note string, chain *SuiteChain, msgs []w.Cosmos
 			Msg:      "aGVsbG8K",
 		},
 	}
-	return s.RoundtripMessage(note, chain, NoteExecute{
+	callback, err := s.RoundtripMessage(note, chain, NoteExecute{
 		Execute: &msg,
 	})
+	return callback.Execute, err
 }
 
-func (s *Suite) RoundtripQuery(note string, chain *SuiteChain, msgs []w.CosmosMsg) (Callback, error) {
+func (s *Suite) RoundtripQuery(note string, chain *SuiteChain, msgs ...w.CosmosMsg) (CallbackDataQuery, error) {
 	msg := NoteQuery{
 		Msgs:           msgs,
 		TimeoutSeconds: 100,
@@ -284,9 +287,10 @@ func (s *Suite) RoundtripQuery(note string, chain *SuiteChain, msgs []w.CosmosMs
 			Msg:      "aGVsbG8K",
 		},
 	}
-	return s.RoundtripMessage(note, chain, NoteExecute{
+	callback, err := s.RoundtripMessage(note, chain, NoteExecute{
 		Query: &msg,
 	})
+	return callback.Query, err
 }
 
 func (s *Suite) RoundtripMessage(note string, chain *SuiteChain, msg NoteExecute) (Callback, error) {

--- a/tests/strangelove/types.go
+++ b/tests/strangelove/types.go
@@ -12,6 +12,8 @@ import (
 // these files every once and a while.
 
 type NoteInstantiate struct {
+	Controller  string `json:"controller,omitempty"`
+	BlockMaxGas uint64 `json:"block_max_gas,string"`
 }
 
 type VoiceInstantiate struct {
@@ -64,8 +66,45 @@ type CallbackMessage struct {
 }
 
 type Callback struct {
-	Success []string `json:"success,omitempty"`
-	Error   string   `json:"error,omitempty"`
+	Execute    CallbackDataExecute `json:"execute,omitempty"`
+	Query      CallbackDataQuery   `json:"query,omitempty"`
+	FatalError string              `json:"fatal_error,omitempty"`
+}
+
+type CallbackDataQuery struct {
+	Ok  [][]byte      `json:"ok,omitempty"`
+	Err ErrorResponse `json:"err,omitempty"`
+}
+
+type CallbackDataExecute struct {
+	Ok  ExecutionResponse `json:"ok,omitempty"`
+	Err string            `json:"err,omitempty"`
+}
+type ExecutionResponse struct {
+	ExecutedBy string           `json:"executed_by"`
+	Result     []SubMsgResponse `json:"result"`
+}
+
+type ErrorResponse struct {
+	MessageIndex uint64 `json:"message_index,string"`
+	Error        string `json:"error"`
+}
+
+type SubMsgResponse struct {
+	Events []Event `json:"events"`
+	Data   []byte  `json:"data,omitempty"`
+}
+
+type Events []Event
+type Event struct {
+	Type       string          `json:"type"`
+	Attributes EventAttributes `json:"attributes"`
+}
+
+type EventAttributes []EventAttribute
+type EventAttribute struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }
 
 type Empty struct{}


### PR DESCRIPTION
We previously removed these due to some bugs in interchaintest. This adds back interchaintest tests with a simple test that can be run without encountering those bugs to demonstrate a full deploy of Polytone for Oak.