### PR TITLE
Fix channel closure and account tracking in callback package.

### DIFF
--- a/contracts/accessories/polytone-tester/src/msg.rs
+++ b/contracts/accessories/polytone-tester/src/msg.rs
@@ -9,7 +9,7 @@ pub enum ExecuteMsg {
     /// Calls `set_data(data)` if `data` is not None.
     Hello { data: Option<Binary> },
     /// Stores the callback in state and makes it queryable
-    Callback(polytone::callback::CallbackMessage),
+    Callback(polytone::callbacks::CallbackMessage),
     /// Runs out of gas.
     RunOutOfGas {},
 }
@@ -28,7 +28,7 @@ pub enum QueryMsg {
 
 #[cw_serde]
 pub struct CallbackHistoryResponse {
-    pub history: Vec<polytone::callback::CallbackMessage>,
+    pub history: Vec<polytone::callbacks::CallbackMessage>,
 }
 
 #[cw_serde]

--- a/contracts/accessories/polytone-tester/src/state.rs
+++ b/contracts/accessories/polytone-tester/src/state.rs
@@ -1,5 +1,5 @@
 use cw_storage_plus::Item;
-use polytone::callback::CallbackMessage;
+use polytone::callbacks::CallbackMessage;
 
 pub(crate) const CALLBACK_HISTORY: Item<Vec<CallbackMessage>> = Item::new("a");
 pub(crate) const HELLO_CALL_HISTORY: Item<Vec<String>> = Item::new("b");

--- a/contracts/main/note/src/error.rs
+++ b/contracts/main/note/src/error.rs
@@ -22,4 +22,7 @@ pub enum ContractError {
 
     #[error("ERR_GAS_NEEDED can't be higher then BLOCK_MAX_GAS")]
     GasLimitsMismatch,
+
+    #[error("channel sequence number overflow, to fix: the contract admin may migrate to close and reopen the channel")]
+    SequenceOverflow,
 }

--- a/contracts/main/note/src/msg.rs
+++ b/contracts/main/note/src/msg.rs
@@ -1,7 +1,7 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{CosmosMsg, Empty, QueryRequest, Uint64};
 
-use polytone::callback::CallbackRequest;
+use polytone::callbacks::CallbackRequest;
 
 #[cw_serde]
 pub struct InstantiateMsg {

--- a/contracts/main/note/src/state.rs
+++ b/contracts/main/note/src/state.rs
@@ -1,4 +1,5 @@
-use cw_storage_plus::Item;
+use cosmwasm_std::{StdResult, Storage};
+use cw_storage_plus::{Item, Map};
 
 /// (Connection-ID, Remote port) of this contract's pair.
 pub const CONNECTION_REMOTE_PORT: Item<(String, String)> = Item::new("a");
@@ -8,4 +9,23 @@ pub const CONNECTION_REMOTE_PORT: Item<(String, String)> = Item::new("a");
 pub const CHANNEL: Item<String> = Item::new("b");
 
 /// Max gas usable in a single block.
-pub(crate) const BLOCK_MAX_GAS: Item<u64> = Item::new("bmg");
+pub const BLOCK_MAX_GAS: Item<u64> = Item::new("bmg");
+
+/// (channel_id) -> sequence number. `u64` is the type used in the
+/// Cosmos SDK for sequence numbers:
+///
+/// <https://github.com/cosmos/ibc-go/blob/a25f0d421c32b3a2b7e8168c9f030849797ff2e8/modules/core/02-client/keeper/keeper.go#L116-L125>
+const SEQUENCE_NUMBER: Map<String, u64> = Map::new("sn");
+
+/// Increments and returns the next sequence number.
+pub(crate) fn increment_sequence_number(
+    storage: &mut dyn Storage,
+    channel_id: String,
+) -> StdResult<u64> {
+    let seq = SEQUENCE_NUMBER
+        .may_load(storage, channel_id.clone())?
+        .unwrap_or_default()
+        + 1;
+    SEQUENCE_NUMBER.save(storage, channel_id, &seq)?;
+    Ok(seq)
+}

--- a/contracts/main/voice/src/ibc.rs
+++ b/contracts/main/voice/src/ibc.rs
@@ -10,7 +10,7 @@ use cosmwasm_std::{
 use cw_utils::{parse_reply_execute_data, MsgExecuteContractResponse};
 use polytone::{
     ack::{ack_execute_fail, ack_fail},
-    callback::Callback,
+    callbacks::Callback,
     handshake::voice,
 };
 

--- a/devtools/optimize.sh
+++ b/devtools/optimize.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-# Run workspace-optimizer
 if [[ $(uname -m) =~ "arm64" ]]; then \
     docker run --rm -v "$(pwd)":/code \
         --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
         --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
         --platform linux/arm64 \
         cosmwasm/workspace-optimizer-arm64:0.12.13
+
 else
     docker run --rm -v "$(pwd)":/code \
         --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
@@ -14,8 +14,3 @@ else
         --platform linux/amd64 \
         cosmwasm/workspace-optimizer:0.12.13
 fi
-
-mkdir -p tests/wasms
-
-# move all wasm files to our tests folder
-cp -R ./artifacts/*.wasm tests/wasms

--- a/justfile
+++ b/justfile
@@ -4,16 +4,30 @@ build:
 test:
     cargo test
 
+# builds the contracts, using the arm64 workspace-optimizer image if
+# avaliable. as this switches images depending on the archetecture,
+# this command should not be used to create release builds.
 optimize:
     ./devtools/optimize.sh
 
 simtest: optimize
+    # normalize names for arm builds.
+    if [[ $(uname -m) =~ "arm64" ]]; then \
+    cp artifacts/polytone_note-aarch64.wasm artifacts/polytone_note.wasm && \
+    cp artifacts/polytone_voice-aarch64.wasm artifacts/polytone_voice.wasm && \
+    cp artifacts/polytone_tester-aarch64.wasm artifacts/polytone_tester.wasm && \
+    cp artifacts/polytone_proxy-aarch64.wasm artifacts/polytone_proxy.wasm \
+    ;fi
+
+    mkdir -p tests/wasms
+    cp -R ./artifacts/*.wasm tests/wasms
+
     go clean -testcache
     cd tests/simtests && go test ./...
 
 integrationtest: optimize
-	go clean -testcache
-	cd tests/strangelove && go test ./...
+    go clean -testcache
+    cd tests/strangelove && go test ./...
 
 # ${f    <-- from variable f
 #   ##   <-- greedy front trim

--- a/packages/polytone/src/accounts.rs
+++ b/packages/polytone/src/accounts.rs
@@ -46,3 +46,40 @@ pub fn on_timeout(storage: &mut dyn Storage, channel_id: String, sequence_number
 pub fn query_account(storage: &dyn Storage, local_address: Addr) -> StdResult<Option<String>> {
     LOCAL_TO_REMOTE_ACCOUNT.may_load(storage, local_address)
 }
+
+#[cfg(test)]
+mod tests {
+    use cosmwasm_std::testing::mock_dependencies;
+
+    use super::*;
+
+    /// In the event of channel closure, this package will see the
+    /// channel ID in packets change. Tests that state is kept
+    /// correctly in this event.
+    #[test]
+    fn test_channel_closure() {
+        let mut deps = mock_dependencies();
+        let storage = deps.as_mut().storage;
+
+        let channel_id = "channel-0".to_string();
+        let sender = Addr::unchecked("sender");
+
+        // send first packet to create account on remote chain.
+        on_send_packet(storage, channel_id.clone(), 1, &sender).unwrap();
+        on_ack(storage, channel_id, 1, Some("remote".to_string()));
+
+        let remote_account = query_account(storage, sender.clone());
+
+        let channel_id = "channel-1".to_string();
+
+        // send first packet to create account on remote chain.
+        on_send_packet(storage, channel_id.clone(), 1, &sender).unwrap();
+        on_ack(storage, channel_id, 1, Some("remote".to_string()));
+
+        let new_remote_account = query_account(storage, sender);
+        assert_eq!(
+            new_remote_account, remote_account,
+            "changing the channel shouldn't change the account"
+        )
+    }
+}

--- a/packages/polytone/src/accounts.rs
+++ b/packages/polytone/src/accounts.rs
@@ -1,0 +1,48 @@
+use cosmwasm_std::{Addr, StdResult, Storage};
+use cw_storage_plus::Map;
+
+/// (channel_id, sequence_number) -> sender
+///
+/// Maps packets to the address that sent them.
+const PENDING: Map<(String, u64), Addr> = Map::new("polytone-accounts-pending");
+
+/// (local_account) -> remote_account
+///
+/// Maps local addresses to their remote counterparts.
+const LOCAL_TO_REMOTE_ACCOUNT: Map<Addr, String> = Map::new("polytone-account-map");
+
+pub fn on_send_packet(
+    storage: &mut dyn Storage,
+    channel_id: String,
+    sequence_number: u64,
+    sender: &Addr,
+) -> StdResult<()> {
+    PENDING.save(storage, (channel_id, sequence_number), sender)
+}
+
+pub fn on_ack(
+    storage: &mut dyn Storage,
+    channel_id: String,
+    sequence_number: u64,
+    executor: Option<String>,
+) {
+    let local_account = PENDING
+        .load(storage, (channel_id.clone(), sequence_number))
+        .expect("pending was set when sending packet");
+
+    PENDING.remove(storage, (channel_id, sequence_number));
+
+    if let Some(executor) = executor {
+        LOCAL_TO_REMOTE_ACCOUNT
+            .save(storage, local_account, &executor)
+            .expect("strings were loaded from storage, so should serialize");
+    }
+}
+
+pub fn on_timeout(storage: &mut dyn Storage, channel_id: String, sequence_number: u64) {
+    PENDING.remove(storage, (channel_id, sequence_number))
+}
+
+pub fn query_account(storage: &dyn Storage, local_address: Addr) -> StdResult<Option<String>> {
+    LOCAL_TO_REMOTE_ACCOUNT.may_load(storage, local_address)
+}

--- a/packages/polytone/src/ack.rs
+++ b/packages/polytone/src/ack.rs
@@ -1,7 +1,7 @@
 use cosmwasm_std::{from_binary, to_binary, Binary, IbcAcknowledgement, SubMsgResponse, Uint64};
 
-pub use crate::callback::Callback;
-use crate::callback::{ErrorResponse, ExecutionResponse};
+pub use crate::callbacks::Callback;
+use crate::callbacks::{ErrorResponse, ExecutionResponse};
 
 /// wasmd 0.32+ will not return a hardcoded ICS-20 ACK if
 /// ibc_packet_receive errors [1] so we can safely use an ACK format

--- a/packages/polytone/src/lib.rs
+++ b/packages/polytone/src/lib.rs
@@ -1,5 +1,6 @@
+pub mod accounts;
 pub mod ack;
-pub mod callback;
+pub mod callbacks;
 pub mod ibc;
 
 pub mod handshake;

--- a/tests/simtests/contract.go
+++ b/tests/simtests/contract.go
@@ -202,3 +202,18 @@ func QueryBlockMaxGas(
 	}
 	return string(query)
 }
+
+func QueryActiveChannel(
+	chain *ibctesting.TestChain,
+	note sdk.AccAddress,
+) string {
+	query, err := chain.App.WasmKeeper.QuerySmart(
+		chain.GetContext(),
+		note,
+		[]byte(NoteQueryActiveChannel),
+	)
+	if err != nil {
+		panic(err)
+	}
+	return string(query)
+}

--- a/tests/simtests/functionality_suite.go
+++ b/tests/simtests/functionality_suite.go
@@ -209,22 +209,6 @@ func (c *Chain) MintBondedDenom(t *testing.T, to sdk.AccAddress) {
 	require.NoError(t, err)
 }
 
-func (c *Chain) CloseNoteChannel(t *testing.T, path *ibctesting.Path) (*sdk.Result, error) {
-	// Contracts are instantiated by the chain default sender and
-	// the note has code ID 1 in SetupChain.
-	a := genAccount(t, c.Chain.SenderPrivKey, c)
-	msg := a.WasmMigrate(&c.Note, `close_channel`, 1)
-	res, err := a.Send(t, msg)
-	if err != nil {
-		return res, err
-	}
-	err = path.EndpointA.Chain.Coordinator.RelayAndAckPendingPackets(path)
-	if err != nil {
-		return res, errors.Join(errors.New("error closing channel"), err)
-	}
-	return res, err
-}
-
 func (s *Suite) RoundtripExecute(t *testing.T, path *ibctesting.Path, account *Account, msgs ...w.CosmosMsg) (CallbackDataExecute, error) {
 	if msgs == nil {
 		msgs = []w.CosmosMsg{}

--- a/tests/simtests/functionality_test.go
+++ b/tests/simtests/functionality_test.go
@@ -471,3 +471,108 @@ func TestInstantiateExecute(t *testing.T) {
 	// But because it can change in the future, we just check its not empty
 	require.NotEmpty(t, response.Address, "address should not be empty")
 }
+
+func TestSimpleChannelClosure(t *testing.T) {
+	suite := NewSuite(t)
+
+	account := GenAccount(t, &suite.ChainA)
+	path := suite.SetupDefaultPath(&suite.ChainA, &suite.ChainB)
+
+	_, err := suite.RoundtripExecute(t, path, &account)
+	require.NoError(t, err, "creating an account should work")
+	remoteAccount := QueryRemoteAccount(suite.ChainA.Chain, suite.ChainA.Note, account.Address)
+	require.NotEqual(t, "null", remoteAccount, "remote account was created")
+
+	suite.Coordinator.CloseChannel(path)
+
+	require.Equal(
+		t,
+		remoteAccount,
+		QueryRemoteAccount(suite.ChainA.Chain, suite.ChainA.Note, account.Address),
+		"remote account is queryable even when channel is closed",
+	)
+
+	aPort := suite.ChainA.QueryPort(suite.ChainA.Note)
+	bPort := suite.ChainB.QueryPort(suite.ChainB.Voice)
+
+	// get around path creation sequence number bug in ibctesting.
+	suite.ChainA.Chain.SenderAccount = account.Acc
+	suite.ChainA.Chain.SenderPrivKey = account.PrivKey
+
+	// try to create a path between the modules on a new
+	// connection. this should fail.
+	_, err = suite.SetupPath(
+		bPort,
+		aPort,
+		&suite.ChainB,
+		&suite.ChainA,
+	)
+	require.ErrorContains(t,
+		err,
+		"contract is already paired with port ("+
+			bPort+
+			") on connection (connection-0), got port ("+
+			bPort+
+			") on connection (connection-1)",
+		"the same port on a different channel is not allowed",
+	)
+	// errors cause sequence numbers to get messed up. i don't
+	// make the rules 🤷
+	account.Acc.SetSequence(account.Acc.GetSequence() + 1)
+
+	// sending a message on a closed channel results in an error.
+	_, err = suite.RoundtripExecute(
+		t,
+		path,
+		&account,
+		HelloMessage(
+			suite.ChainB.Tester,
+			"👌",
+		),
+	)
+	require.ErrorContains(t,
+		err,
+		"contract has no pair, establish a channel with a voice module to create one",
+		"messages can not be executed when the channel is closed",
+	)
+
+	account = GenAccount(t, &suite.ChainA)
+	suite.ChainA.Chain.SenderAccount = account.Acc
+	suite.ChainA.Chain.SenderPrivKey = account.PrivKey
+
+	// Create a new channel, on the original connection. Doing
+	// this requires a bit of a hack where we reset the path's
+	// channel information to its default values and then create a
+	// new channel. ibctesting doesn't have a "way" to do this, so
+	// this seemed like the lowest-effort hack.
+	path.EndpointA.ChannelConfig = ChannelConfig(aPort)
+	path.EndpointB.ChannelConfig = ChannelConfig(bPort)
+	path.EndpointA.ChannelID = ""
+	path.EndpointB.ChannelID = ""
+
+	// This should create a channel! or error. But clearly it does
+	// not because there is no code path that calls into
+	// ibc_confirm and doesn't set the active channel. Fuck.
+	suite.Coordinator.CreateChannels(path)
+
+	activeChannel := QueryActiveChannel(suite.ChainA.Chain, suite.ChainA.Note)
+	require.Equal(t, `"channel-1"`, activeChannel, "a new channel should have been created")
+
+	callback, err := suite.RoundtripExecute(
+		t,
+		path,
+		&account,
+		HelloMessage(
+			suite.ChainB.Tester,
+			"👌",
+		),
+	)
+	require.NoError(t, err, "messages can be executed now that the channel is reopened")
+	require.Equal(t, "👌", callback.Ok.Result[0].Data)
+	require.Equal(
+		t,
+		remoteAccount,
+		QueryRemoteAccount(suite.ChainA.Chain, suite.ChainA.Note, account.Address),
+		"remote account has not changed",
+	)
+}

--- a/tests/simtests/wasm_msg.go
+++ b/tests/simtests/wasm_msg.go
@@ -21,6 +21,20 @@ func (a *Account) WasmExecute(contract *sdk.AccAddress, msg any, funds ...sdk.Co
 	}
 }
 
+// `WasmMsg::Migrate` with the account as the sender.
+func (a *Account) WasmMigrate(contract *sdk.AccAddress, msg any, codeId uint64, funds ...sdk.Coin) sdk.Msg {
+	msgstr, err := json.Marshal(msg)
+	if err != nil {
+		panic(err)
+	}
+	return &wasm.MsgMigrateContract{
+		Sender:   a.Address.String(),
+		Contract: contract.String(),
+		Msg:      wasm.RawContractMessage(msgstr),
+		CodeID:   codeId,
+	}
+}
+
 // `WasmMsg::Instantiate` with the account as the sender.
 func (a *Account) WasmInstantiate(codeId uint64, msg any, admin *sdk.AccAddress, funds ...sdk.Coin) sdk.Msg {
 	msgstr, err := json.Marshal(msg)


### PR DESCRIPTION
Before this change:

1. The account map wasn't populated if no callback was requested during execution.
2. Sequence number wasn't namespaced by channel_id, which would cause incorrect callbacks to be sent in the event of a channel closing.